### PR TITLE
Handle invalid basic auth headers

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -2,10 +2,21 @@ export const onRequest: PagesFunction<{ BASIC_USER?: string; BASIC_PASS?: string
   const user = ctx.env.BASIC_USER || "mildred";
   const pass = ctx.env.BASIC_PASS || "knit";
   const header = ctx.request.headers.get("Authorization") || "";
-  const ok = header.startsWith("Basic ") && (() => {
-    const [u, p] = atob(header.slice(6)).split(":");
-    return u === user && p === pass;
-  })();
+
+  let ok = false;
+  if (header.startsWith("Basic ")) {
+    try {
+      const decoded = atob(header.slice(6));
+      const idx = decoded.indexOf(":");
+      if (idx !== -1) {
+        const u = decoded.slice(0, idx);
+        const p = decoded.slice(idx + 1);
+        ok = u === user && p === pass;
+      }
+    } catch {
+      ok = false;
+    }
+  }
   if (!ok) {
     return new Response("Auth required", {
       status: 401,

--- a/public/index.html
+++ b/public/index.html
@@ -279,7 +279,10 @@
         const size = document.createElement('span'); size.className='size'; size.textContent = humanSize(a.file.size);
         info.append(name, size);
 
-        const bar = document.createElement('div'); bar.className='bar'; const inner = document.createElement('span'); bar.appendChild(inner);
+        const bar = document.createElement('div');
+        bar.className = 'bar';
+        const inner = document.createElement('span');
+        bar.appendChild(inner);
         if (a.uploading) { inner.style.setProperty('--p', a.progress + '%'); } else { bar.style.display='none'; }
 
         const remove = document.createElement('button'); remove.className='remove'; remove.setAttribute('aria-label', `Remove ${a.file.name}`); remove.textContent = '×';


### PR DESCRIPTION
## Summary
- guard the basic auth middleware against malformed `Authorization` headers so that invalid base64 no longer crashes the request
- tidy the attachment progress bar DOM construction for readability while reviewing the previews rendering logic

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e3e8b135e48323846ebbe1d258350a