### PR TITLE
Fix attachment removal for non-image files

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -286,7 +286,12 @@
         if (a.uploading) { inner.style.setProperty('--p', a.progress + '%'); } else { bar.style.display='none'; }
 
         const remove = document.createElement('button'); remove.className='remove'; remove.setAttribute('aria-label', `Remove ${a.file.name}`); remove.textContent = '×';
-        remove.onclick = () => { URL.revokeObjectURL(a.url); attachments = attachments.filter(x => x.id !== a.id); renderPreviews(); updateAttachmentIndicators(); };
+        remove.onclick = () => {
+          if (a.url) { URL.revokeObjectURL(a.url); }
+          attachments = attachments.filter(x => x.id !== a.id);
+          renderPreviews();
+          updateAttachmentIndicators();
+        };
 
         el.append(thumb, info, bar, remove);
         previewsEl.appendChild(el);


### PR DESCRIPTION
## Summary
- avoid revoking empty object URLs when removing file previews
- ensure non-image attachments can be removed without errors

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e3f61f397c8323905012ee70f3160b