### PR TITLE
Connect send button to backend and show replies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,57 @@
     h1{ margin:0; font-size:18px; letter-spacing:.2px }
     .sub{ color:#394056; opacity:.8; font-size:13px }
 
-    main{ display:grid; align-content:end; }
+    main{ display:grid; grid-template-rows: 1fr auto; gap:18px; min-height:0; }
+
+    .history{
+      position:relative;
+      overflow-y:auto;
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+      padding:16px;
+      border-radius:18px;
+      border:1px solid var(--ridge);
+      background: color-mix(in oklab, #fff 80%, var(--bg));
+      box-shadow: inset 0 1px 0 #fff8;
+      min-height:200px;
+    }
+    .history:empty::before{
+      content:"Ask Mildred about cables, lace, or yarn substitutions to get started.";
+      color:#364155;
+      opacity:.6;
+      font-size:14px;
+    }
+
+    .bubble{
+      max-width:min(100%, 560px);
+      padding:12px 14px;
+      border-radius:16px 16px 16px 6px;
+      background:#fff;
+      box-shadow:0 1px 0 #fff inset, 0 3px 12px #0001;
+      display:grid;
+      gap:6px;
+      color:var(--ink);
+    }
+    .bubble-user{
+      margin-left:auto;
+      border-radius:16px 16px 6px 16px;
+      background:linear-gradient(135deg, var(--accent-kingfisher), var(--accent-moss));
+      color:#fff;
+      box-shadow:0 3px 12px #0003;
+    }
+    .bubble-error{
+      background:#fff3f1;
+      border:1px solid color-mix(in oklab, var(--accent-amber) 24%, #fff);
+      color:#401000;
+    }
+    .bubble-speaker{
+      font:600 11px/1 var(--font-mono);
+      letter-spacing:.3px;
+      text-transform:uppercase;
+      opacity:.6;
+    }
+    .bubble-body{ font:15px/1.45 var(--font-sans); white-space:pre-wrap; }
 
     /* Input bar */
     .inputbar{ position:sticky; bottom:0; backdrop-filter:saturate(1.1) blur(6px); padding:8px 0 16px; }
@@ -134,6 +184,8 @@
     /* Small */
     @media (max-width: 640px){
       .wrap{ padding:16px }
+      main{ grid-template-rows: minmax(200px, 1fr) auto }
+      .history{ padding:12px; border-radius:14px }
       .input{ grid-template-columns: 38px 1fr 84px }
       .btn{ padding:0 10px }
     }
@@ -150,6 +202,7 @@
     </header>
 
     <main>
+      <section class="history" id="history" aria-live="polite" aria-label="Conversation"></section>
       <div class="inputbar" role="region" aria-label="Knitting input">
         <div class="chips" role="group" aria-label="Quick prompts">
           <button class="chip" data-insert="Cast-on">Cast‑on</button>
@@ -193,6 +246,7 @@
     const sendBtn    = document.getElementById('sendBtn');
     const msg        = document.getElementById('msg');
     const srStatus   = document.getElementById('srStatus');
+    const history    = document.getElementById('history');
 
     let attachments = []; // { id, file, url, type, uploading, progress }
     let isComposing = false; // IME safety
@@ -320,6 +374,21 @@
 
     // Send logic in a reusable function
     async function triggerSend(){
+      if (sendBtn.disabled) return;
+
+      const message = msg.value.trim();
+      if (!message) {
+        announce('Type a message before sending');
+        msg.focus();
+        return;
+      }
+
+      appendMessage('user', message);
+      const originalLabel = sendBtn.textContent;
+      sendBtn.disabled = true;
+      sendBtn.setAttribute('aria-busy', 'true');
+      sendBtn.textContent = 'Sending…';
+
       // mark uploading
       for (const a of attachments){ a.uploading = true; a.progress = 10; }
       renderPreviews();
@@ -329,22 +398,66 @@
         for (let p=10; p<=100; p+=30){ await new Promise(r=>setTimeout(r,130)); a.progress = p; renderPreviews(); }
       }
 
-      // Example payload you might send to your model/backend
-      const payload = {
-        message: msg.value.trim(),
-        files: attachments.map(a => ({ name: a.file.name, type: a.type, size: a.file.size }))
-      };
-      console.log('Send payload →', payload);
+      try {
+        const resp = await fetch('/api/ask', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            prompt: message,
+            files: attachments.map(a => ({ name: a.file.name, type: a.type, size: a.file.size }))
+          })
+        });
 
-      // cleanup previews (leave message as-is for convenience)
-      attachments.forEach(a => a.url && URL.revokeObjectURL(a.url));
-      attachments = [];
-      renderPreviews();
-      announce('Message sent');
+        if (!resp.ok) {
+          const text = await resp.text();
+          throw new Error(text || `Request failed with ${resp.status}`);
+        }
+
+        const reply = await resp.text();
+        appendMessage('assistant', reply.trim() || 'No answer.');
+        msg.value = '';
+        msg.dispatchEvent(new Event('input'));
+        announce('Message sent');
+
+        attachments.forEach(a => a.url && URL.revokeObjectURL(a.url));
+        attachments = [];
+        renderPreviews();
+      } catch (err) {
+        console.error(err);
+        appendMessage('error', err?.message || 'Something went wrong.');
+        for (const a of attachments){ a.uploading = false; a.progress = 0; }
+        renderPreviews();
+        announce('Message failed');
+      } finally {
+        sendBtn.disabled = false;
+        sendBtn.removeAttribute('aria-busy');
+        sendBtn.textContent = originalLabel;
+        msg.focus();
+      }
     }
 
     // Buttons
     sendBtn.addEventListener('click', triggerSend);
+
+    appendMessage('assistant', 'Hi there! I am Mildred — what knitting trouble can I help unravel today?');
+
+    function appendMessage(kind, text){
+      if (!history) return;
+      const bubble = document.createElement('article');
+      bubble.className = `bubble bubble-${kind}`;
+
+      const speaker = document.createElement('div');
+      speaker.className = 'bubble-speaker';
+      speaker.textContent = kind === 'user' ? 'You' : kind === 'assistant' ? 'Mildred' : 'Oops';
+
+      const body = document.createElement('div');
+      body.className = 'bubble-body';
+      body.textContent = String(text ?? '');
+
+      bubble.append(speaker, body);
+      history.appendChild(bubble);
+      history.scrollTop = history.scrollHeight;
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a conversation history panel with styled message bubbles
- wire the send button to call the /api/ask endpoint and surface replies and errors
- update status handling so failed requests restore attachments and announce results

## Testing
- ⚠️ `npx --yes serve public -l 4173` *(fails: npm registry 403 in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41519dc7c832389b18e757e38a2a6